### PR TITLE
Support passing gradle arguments

### DIFF
--- a/kobweb/src/main/kotlin/com/varabyte/kobweb/cli/export/Export.kt
+++ b/kobweb/src/main/kotlin/com/varabyte/kobweb/cli/export/Export.kt
@@ -21,14 +21,19 @@ private enum class ExportState {
     INTERRUPTED,
 }
 
-fun handleExport(projectDir: File, siteLayout: SiteLayout, useAnsi: Boolean) {
+fun handleExport(projectDir: File, siteLayout: SiteLayout, useAnsi: Boolean, gradleArgs: List<String>) {
     // exporting is a production-only action
     KobwebGradle(ServerEnvironment.PROD, projectDir).use { kobwebGradle ->
-        handleExport(siteLayout, useAnsi, kobwebGradle)
+        handleExport(siteLayout, useAnsi, kobwebGradle, gradleArgs)
     }
 }
 
-private fun handleExport(siteLayout: SiteLayout, useAnsi: Boolean, kobwebGradle: KobwebGradle) {
+private fun handleExport(
+    siteLayout: SiteLayout,
+    useAnsi: Boolean,
+    kobwebGradle: KobwebGradle,
+    gradleArgs: List<String>,
+) {
     var runInPlainMode = !useAnsi
 
     if (useAnsi && !trySession {
@@ -64,7 +69,7 @@ private fun handleExport(siteLayout: SiteLayout, useAnsi: Boolean, kobwebGradle:
             }
         }.run {
             val exportProcess = try {
-                kobwebGradle.export(siteLayout)
+                kobwebGradle.export(siteLayout, gradleArgs)
             }
             catch (ex: Exception) {
                 exception = ex
@@ -116,7 +121,7 @@ private fun handleExport(siteLayout: SiteLayout, useAnsi: Boolean, kobwebGradle:
         assertKobwebApplication(kobwebGradle.projectDir.toPath())
             .also { kobwebApplication -> kobwebApplication.assertServerNotAlreadyRunning() }
 
-        kobwebGradle.export(siteLayout).also { it.waitFor() }
+        kobwebGradle.export(siteLayout, gradleArgs).also { it.waitFor() }
         kobwebGradle.stopServer().also { it.waitFor() }
     }
 }

--- a/kobweb/src/main/kotlin/com/varabyte/kobweb/cli/run/Run.kt
+++ b/kobweb/src/main/kotlin/com/varabyte/kobweb/cli/run/Run.kt
@@ -43,12 +43,13 @@ fun handleRun(
     siteLayout: SiteLayout,
     useAnsi: Boolean,
     runInForeground: Boolean,
+    gradleArgs: List<String>,
 ) {
     val originalEnv = env
 
     @Suppress("NAME_SHADOWING") // We're intentionally intercepting the original value
     val env = env.takeIf { siteLayout != SiteLayout.STATIC } ?: ServerEnvironment.PROD
-    KobwebGradle(env, projectDir).use { kobwebGradle -> handleRun(originalEnv, env, siteLayout, useAnsi, runInForeground, kobwebGradle) }
+    KobwebGradle(env, projectDir).use { kobwebGradle -> handleRun(originalEnv, env, siteLayout, useAnsi, runInForeground, kobwebGradle, gradleArgs) }
 }
 
 private fun handleRun(
@@ -58,6 +59,7 @@ private fun handleRun(
     useAnsi: Boolean,
     runInForeground: Boolean,
     kobwebGradle: KobwebGradle,
+    gradleArgs: List<String>,
 ) {
     var runInPlainMode = !useAnsi
     if (useAnsi && !trySession {
@@ -153,7 +155,7 @@ private fun handleRun(
             }
         }.runUntilSignal {
             val startServerProcess = try {
-                kobwebGradle.startServer(enableLiveReloading = (env == ServerEnvironment.DEV), siteLayout)
+                kobwebGradle.startServer(enableLiveReloading = (env == ServerEnvironment.DEV), siteLayout, gradleArgs)
             }
             catch (ex: Exception) {
                 exception = ex
@@ -249,7 +251,7 @@ private fun handleRun(
 
         // If we're non-interactive, it means we just want to start the Kobweb server and exit without waiting for
         // for any additional changes. (This is essentially used when run in a web server environment)
-        kobwebGradle.startServer(enableLiveReloading = false, siteLayout).also { it.waitFor() }
+        kobwebGradle.startServer(enableLiveReloading = false, siteLayout, gradleArgs).also { it.waitFor() }
 
         val serverStateFile = ServerStateFile(kobwebApplication.kobwebFolder)
         runBlocking {

--- a/kobweb/src/main/kotlin/com/varabyte/kobweb/cli/stop/Stop.kt
+++ b/kobweb/src/main/kotlin/com/varabyte/kobweb/cli/stop/Stop.kt
@@ -12,17 +12,18 @@ private enum class StopState {
     STOPPED,
 }
 
-fun handleStop(projectDir: File, useAnsi: Boolean) {
+fun handleStop(projectDir: File, useAnsi: Boolean, gradleArgs: List<String>) {
     // Server environment doesn't really matter for "stop". Still, let's default to prod because that's usually the case
     // where a server is left running for a long time.
     KobwebGradle(ServerEnvironment.PROD, projectDir).use { kobwebGradle ->
-        handleStop(useAnsi, kobwebGradle)
+        handleStop(useAnsi, kobwebGradle, gradleArgs)
     }
 }
 
 private fun handleStop(
     useAnsi: Boolean,
     kobwebGradle: KobwebGradle,
+    gradleArgs: List<String>,
 ) {
     var runInPlainMode = !useAnsi
 
@@ -45,7 +46,7 @@ private fun handleStop(
                     }
                 }
             }.run {
-                val stopServerProcess = kobwebGradle.stopServer()
+                val stopServerProcess = kobwebGradle.stopServer(gradleArgs)
                 stopServerProcess.lineHandler = ::handleConsoleOutput
                 stopServerProcess.waitFor()
                 stopState = StopState.STOPPED
@@ -68,6 +69,6 @@ private fun handleStop(
             return
         }
 
-        kobwebGradle.stopServer().also { it.waitFor() }
+        kobwebGradle.stopServer(gradleArgs).also { it.waitFor() }
     }
 }

--- a/kobweb/src/main/kotlin/main.kt
+++ b/kobweb/src/main/kotlin/main.kt
@@ -60,6 +60,12 @@ private fun ParameterHolder.notty() = option("--notty",
     help = "Explicitly disable TTY support. In this case, runs in plain mode, logging output sequentially without listening for user input, which is useful for CI environments or Docker containers.",
 ).counted().validate { require(it <= 1) { "Cannot specify `--notty` more than once" } }
 
+private fun ParameterHolder.gradleArgs() = option("--gradle",
+    help = "Arguments that will be passed to the main Gradle command. Surround with quotes for multiple arguments or if there are spaces."
+)
+    .convert { args -> args.split(' ').filter { it.isNotBlank() } }
+    .default(emptyList(), defaultForHelp = "none")
+
 private fun Mode.toTtyParam() = when (this) {
     Mode.INTERACTIVE -> "--tty"
     Mode.DUMB -> "--notty"
@@ -195,10 +201,11 @@ fun main(args: Array<String>) {
         val mode by mode()
         val layout by layout()
         val path by path()
+        val gradleArgs by gradleArgs()
 
         override fun shouldCheckForUpgrade() = shouldUseAnsi(tty, notty, mode)
         override fun doRun() {
-            handleExport(path, layout, shouldUseAnsi(tty, notty, mode))
+            handleExport(path, layout, shouldUseAnsi(tty, notty, mode), gradleArgs)
         }
     }
 
@@ -210,10 +217,11 @@ fun main(args: Array<String>) {
         val mode by mode()
         val layout by layout()
         val path by path()
+        val gradleArgs by gradleArgs()
 
         override fun shouldCheckForUpgrade() = shouldUseAnsi(tty, notty, mode)
         override fun doRun() {
-            handleRun(env, path, layout, shouldUseAnsi(tty, notty, mode), foreground)
+            handleRun(env, path, layout, shouldUseAnsi(tty, notty, mode), foreground, gradleArgs)
         }
     }
 
@@ -222,13 +230,14 @@ fun main(args: Array<String>) {
         val notty by notty()
         val mode by mode()
         val path by path()
+        val gradleArgs by gradleArgs()
 
         // Don't check for an upgrade on create, because the user probably just installed kobweb anyway, and the update
         // message kind of overwhelms the instructions to start running the app.
         override fun shouldCheckForUpgrade() = false
 
         override fun doRun() {
-            handleStop(path, shouldUseAnsi(tty, notty, mode))
+            handleStop(path, shouldUseAnsi(tty, notty, mode), gradleArgs)
         }
     }
 


### PR DESCRIPTION
Note that these gradle arguments are only used for the "main" task of the command (e.g., only `kobwebStart` for `kobweb run`, only `kobwebExport` for `kobweb export`).