### PR TITLE
Minimize the bundle size using Proguard

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ kobweb-libs = "0.17.1"
 kotter = "1.1.2"
 kotlin = "1.8.10"
 kotlinx-coroutines = "1.6.0"
-okhttp = "4.10.0"
+okhttp = "4.12.0"
 shadow = "7.0.0"
 proguard = "7.5.0"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ kotlin = "1.8.10"
 kotlinx-coroutines = "1.6.0"
 okhttp = "4.10.0"
 shadow = "7.0.0"
+proguard = "7.5.0"
 
 [libraries]
 clikt = { module = "com.github.ajalt.clikt:clikt", version.ref = "clikt" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,3 +26,4 @@ jreleaser = { id = "org.jreleaser", version.ref = "jreleaser" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 shadow = { id = "com.github.johnrengelman.shadow", version.ref = "shadow" }
+proguard = { id = "com.guardsquare:proguard-gradle", version.ref = "proguard" }

--- a/kobweb/build.gradle.kts
+++ b/kobweb/build.gradle.kts
@@ -74,7 +74,7 @@ tasks.jar {
     archiveFileName.set("kobweb-cli.jar")
 }
 
-// Proguard for minimizing the JAR file
+// Proguard for minimizing the bundle size
 buildscript {
     repositories { mavenCentral() }
     dependencies {

--- a/kobweb/proguard.pro
+++ b/kobweb/proguard.pro
@@ -1,0 +1,40 @@
+# This file contain the rules that's either specific to the project or custom rules that's not from the dependencies
+# and it doesn't contain the required configurations as it's already configured by Gradle task
+
+# Proguard Kotlin Example https://github.com/Guardsquare/proguard/blob/master/examples/application-kotlin/proguard.pro
+
+-keepattributes *Annotation*
+
+# Entry point to the app.
+-keep class MainKt { *; }
+
+# Ignore all the warnings from Kotlinx Coroutines
+-dontwarn kotlinx.coroutines.**
+
+# Leave Jansi deps in place, or else Windows won't work
+-keep class org.fusesource.jansi.** { *; }
+-keep class org.jline.jline-terminal-jansi.** { *; }
+
+# Exclude SLF4J from minimization
+-keep class org.slf4j.** { *; }
+-dontwarn org.slf4j.**
+
+# Suppress warnings coming from Gradle API
+-dontwarn org.gradle.**
+
+# Suppress and fix Freemarker warnings
+-dontwarn freemarker.ext.**
+-dontwarn freemarker.template.utility.JythonRuntime
+-keep class freemarker.template.utility.JythonRuntime
+
+# Suppress warnings about missing classes from 'org.python package'
+# Freemarker relies on Jython, and some Jython classes may not be recognized.
+-dontwarn org.python.**
+
+# Suppress warnings from Javax Servlet as Freemarker depends on it and is already part of the JAR
+-dontwarn javax.servlet.**
+
+# Suppress warnings from Apache Logging as Freemarker depends on it
+-dontwarn org.apache.log4j.**
+-dontwarn org.apache.commons.logging.**
+-dontwarn org.apache.log.**


### PR DESCRIPTION
Minimize the bundle size by using [Proguard](https://github.com/Guardsquare/proguard)

**Before**: 12.5 MB
**With Proguard**: 4.83 MB (reduced by 59.30%)
**With Proguard (obfuscation enabled)**: 2.86 MB (reduced by 75.91%)

The `proguard` task is configured to use the rules that are included in the JAR file in `META-INF/proguard` which will exist even if not using Proguard, as the required rules won't be included by default as there might be some downsides, one of them if a library update the rules we will have to update the library to get the updated rules, another way to address this is by fetching the rules from the repository and include it in a task, this also have downsides, some new rules for the updated library might not work with the current version

We also could manually update the rules and this will require checking if the rules have been updated when updating the libraries that have Proguard support, this solution is commonly used by most projects

I have not encountered any issues with the current solution and it's similar to R8

I have updated OkHttp from `4.10.0` to `4.12.0` to fix some warnings as the latest stable has default rules (in `META-INF/proguard/okhttp3.pro`) that will fix the encountered warnings, this change could be reverted and fixed either by including the latest rules manually (could be outdated after a while) or only the changes, or ignore the warnings.

The `proguard` task will read the rules from `META-INF/proguard`

The libraries in the project that support Proguard are:
- OkHttp and Okio (used by OkHttp)
- Kotlinx Coroutines
- Kotlinx Serialization

There might be other dependencies that support Proguard such as **Google Guava** (https://github.com/google/guava/wiki/UsingProGuardWithGuava) though the rules are in a custom location (https://github.com/google/guava/tree/master/proguard) instead of `resources/META-INF/proguard` as a result the task won't be able to include it and will have to include it manually

It's not recommended to use `-ignorewarnings`, see [this comment](https://github.com/square/okio/issues/1298#issuecomment-1652182091) for more details
If the warning has an import that's from the JDK, try to include the required modules from the JDK, I included only the required modules so in the future if you use a new module, you will have to include it manually and will get warning that cause build failure, we could also include all modules

Proguard will be able to detect the most common usages of reflections and will cause a build failure with warnings that need to be solved (https://www.guardsquare.com/manual/home) to avoid runtime exceptions, however, some warnings should be suppressed as it will not cause any issues

I disabled obfuscation to make debugging easier, although if you want to save more, we might want to consider enabling it.

I haven't fully tested the CLI yet.

The GitHub workflow could upload the minimized JAR file in Github releases (with a note indicating it's not stable yet), or release this change as experimental to avoid disrupting the developers

This change might introduce additional maintenance needs, we could also drop the change.